### PR TITLE
Update Invoke-LenovoBIOSUpdate.ps1

### DIFF
--- a/Operating System Deployment/BIOS/Invoke-LenovoBIOSUpdate.ps1
+++ b/Operating System Deployment/BIOS/Invoke-LenovoBIOSUpdate.ps1
@@ -106,7 +106,9 @@ Process {
 	if ((Test-Path -Path (Join-Path -Path $Path -ChildPath "OLEDLG.dll")) -eq $False) {
 		Write-CMLogEntry -Value "Copying OLEDLG.dll to $($Path) directory" -Severity 1
 		if (([string]::IsNullOrEmpty($TSEnvironment.Value("OSDisk"))) -eq $false) {
-			Copy-Item -Path (Join-Path -path $TSEnvironment.Value("OSDisk") -ChildPath "Windows\System32\OLEDLG.dll") -Destination "$($Path)\OLEDLG.dll"
+			IF (Test-Path -Path (Join-Path -path $TSEnvironment.Value("OSDisk") -ChildPath "Windows\System32\OLEDLG.dll")){
+				Copy-Item -Path (Join-Path -path $TSEnvironment.Value("OSDisk") -ChildPath "Windows\System32\OLEDLG.dll") -Destination "$($Path)\OLEDLG.dll"
+			}
 		}
 		elseif ((Test-Path -Path "C:\Windows\System32\OLEDLG.dll") -eq $true) {
 			Copy-Item -Path "C:\Windows\System32\OLEDLG.dll" -Destination "$($Path)\OLEDLG.dll"


### PR DESCRIPTION
Update is necessary if you want to update BIOS before applying OS to OSDisk. Otherwise throws error because file does not exist.
TESTED!