### PR TITLE
Update for Win10 2004 Features on Demand

### DIFF
--- a/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
+++ b/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
@@ -27,7 +27,7 @@
 #>
 Begin {
     # White list of Features On Demand V2 packages
-    $WhiteListOnDemand = "NetFX3|Tools.Graphics.DirectX|Tools.DeveloperMode.Core|Language|Browser.InternetExplorer|ContactSupport|OneCoreUAP|Media.WindowsMediaPlayer|Hello.Face"
+        $WhiteListOnDemand = "NetFX3|Tools.Graphics.DirectX|Tools.DeveloperMode.Core|Language|Browser.InternetExplorer|ContactSupport|OneCoreUAP|Media.WindowsMediaPlayer|Hello.Face|Microsoft.Windows.Notepad|Microsoft.Windows.ISE|Microsoft.Windows.Wordpad|Windows.Client.ShellComponents"
 
     # White list of appx packages to keep installed
     $WhiteListedApps = New-Object -TypeName System.Collections.ArrayList

--- a/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
+++ b/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
@@ -27,7 +27,7 @@
 #>
 Begin {
     # White list of Features On Demand V2 packages
-        $WhiteListOnDemand = "NetFX3|Tools.Graphics.DirectX|Tools.DeveloperMode.Core|Language|Browser.InternetExplorer|ContactSupport|OneCoreUAP|Media.WindowsMediaPlayer|Hello.Face|Microsoft.Windows.Notepad|Microsoft.Windows.ISE|Microsoft.Windows.Wordpad|Windows.Client.ShellComponents"
+    $WhiteListOnDemand = "NetFX3|Tools.Graphics.DirectX|Tools.DeveloperMode.Core|Language|Browser.InternetExplorer|ContactSupport|OneCoreUAP|Media.WindowsMediaPlayer|Hello.Face|Microsoft.Windows.Notepad|Microsoft.Windows.ISE|Microsoft.Windows.Wordpad|Windows.Client.ShellComponents"
 
     # White list of appx packages to keep installed
     $WhiteListedApps = New-Object -TypeName System.Collections.ArrayList

--- a/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
+++ b/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
@@ -27,23 +27,23 @@
 #>
 Begin {
     # White list of Features On Demand V2 packages
-    $WhiteListOnDemand = "NetFX3|Tools.Graphics.DirectX|Tools.DeveloperMode.Core|Language|Browser.InternetExplorer|ContactSupport|OneCoreUAP|Media.WindowsMediaPlayer|Hello.Face|Microsoft.Windows.Notepad|Microsoft.Windows.ISE|Microsoft.Windows.Wordpad|Windows.Client.ShellComponents"
+    $WhiteListOnDemand = "NetFX3|Tools.Graphics.DirectX|Tools.DeveloperMode.Core|Language|Browser.InternetExplorer|ContactSupport|OneCoreUAP|Media.WindowsMediaPlayer|Hello.Face|Microsoft.Windows.Notepad|Microsoft.Windows.ISE|Microsoft.Windows.WordPad|Microsoft.Windows.MSPaint|Microsoft.Windows.PowerShell.ISE|App.StepsRecorder|Windows.Client.ShellComponents|DirectX.Configuration.Database"
 
     # White list of appx packages to keep installed
     $WhiteListedApps = New-Object -TypeName System.Collections.ArrayList
     $WhiteListedApps.AddRange(@(
         "Microsoft.DesktopAppInstaller",
         "Microsoft.Office.OneNote",
-        "Microsoft.Messaging", 
+        "Microsoft.Messaging",
         "Microsoft.MSPaint",
         "Microsoft.Windows.Photos",
         "Microsoft.StorePurchaseApp",
         "Microsoft.MicrosoftOfficeHub",
         "Microsoft.MicrosoftStickyNotes",
         "Microsoft.WindowsAlarms",
-        "Microsoft.WindowsCalculator", 
+        "Microsoft.WindowsCalculator",
         "Microsoft.WindowsCommunicationsApps", # Mail, Calendar etc
-        "Microsoft.WindowsSoundRecorder", 
+        "Microsoft.WindowsSoundRecorder",
         "Microsoft.WindowsStore"
     ))
 
@@ -103,7 +103,7 @@ Process {
             $AppProvisioningPackageName = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -like $App } | Select-Object -ExpandProperty PackageName -First 1
 
             # Attempt to remove AppxPackage
-            if ($AppPackageFullName -ne $null) {
+            if ($null -ne $AppPackageFullName) {
                 try {
                     Write-LogEntry -Value "Removing AppxPackage: $($AppPackageFullName)"
                     Remove-AppxPackage -Package $AppPackageFullName -ErrorAction Stop | Out-Null
@@ -117,7 +117,7 @@ Process {
             }
 
             # Attempt to remove AppxProvisioningPackage
-            if ($AppProvisioningPackageName -ne $null) {
+            if ($null -ne $AppProvisioningPackageName) {
                 try {
                     Write-LogEntry -Value "Removing AppxProvisioningPackage: $($AppProvisioningPackageName)"
                     Remove-AppxProvisionedPackage -PackageName $AppProvisioningPackageName -Online -ErrorAction Stop | Out-Null
@@ -161,7 +161,7 @@ Process {
             catch [System.Exception] {
                 Write-LogEntry -Value "Removing Feature on Demand V2 package failed: $($_.Exception.Message)"
             }
-        }    
+        }
     }
     catch [System.Exception] {
         Write-LogEntry -Value "Attempting to list Feature on Demand V2 packages failed: $($_.Exception.Message)"


### PR DESCRIPTION
Win10 2004 moves some apps to be FeatureOnDemand: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/features-on-demand-non-language-fod

Updated WhiteListOnDemand to keep some of the important ones for end users (wordpad, notepad, desktop experience, etc.).

Set $null on left in conditionals per PSScriptAnalyszer: https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/PossibleIncorrectComparisonWithNull.md