### PR TITLE
Update to Invoke-RemoveBuiltinApps.ps1

### DIFF
--- a/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
+++ b/Operating System Deployment/Invoke-RemoveBuiltinApps.ps1
@@ -28,7 +28,7 @@
 #>
 Begin {
     # White list of Features On Demand V2 packages
-    $WhiteListOnDemand = "NetFX3|DirectX|Tools.DeveloperMode.Core|Language|InternetExplorer|ContactSupport|OneCoreUAP|WindowsMediaPlayer|Hello.Face|Notepad|MSPaint|PowerShell.ISE|ShellComponents"
+    $WhiteListOnDemand = "NetFX3|DirectX|Tools.DeveloperMode.Core|Language|InternetExplorer|ContactSupport|OneCoreUAP|WindowsMediaPlayer|Hello.Face|Print.Management.Console|Print.Fax.Scan|Notepad|MSPaint|PowerShell.ISE|Windows.Client.ShellComponents"
 
     # White list of appx packages to keep installed
     $WhiteListedApps = New-Object -TypeName System.Collections.ArrayList


### PR DESCRIPTION
Hi,

Not sure if anyone else has experienced this but the issue I have been seeing using this updated PS script is that the Snip & Sketch app breaks and doesn't work correctly, which I suspect may have something to do with the FoD component - Windows.Client.ShellComponents. I noticed in the script its defined as 'ShellComponents' under the FoD V2 packages section. Although this should work anyway using the query further down the script but when I changed it to 'Windows.Client.ShellComponents' and ran the script again from our build environment (MDT Task Sequence) Snip and Sketch worked fine with no issues. I've also had to add 'Print.Management.Console' and 'Print.Fax.Scan' under '# White list of Features On Demand V2 packages' but this is specific to our business needs and wouldn't think it would apply to everyone :) 

Regards,
Asaf